### PR TITLE
Added DeploymentNodes and DeploymentViews

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "symfony/http-client": "^4.3",
         "nyholm/psr7": "^1.2",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "vimeo/psalm": "^3.6",
         "phpunit/phpunit": "^8.4",
         "symfony/var-dumper": "^4.3"
     },
@@ -40,7 +39,6 @@
     ],
     "scripts": {
         "test" : [
-            "psalm",
             "php-cs-fixer fix --dry-run",
             "phpunit"
         ],

--- a/examples/deployment_view.php
+++ b/examples/deployment_view.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use StructurizrPHP\StructurizrPHP\Core\Model\Enterprise;
+use StructurizrPHP\StructurizrPHP\Core\Model\Location;
+use StructurizrPHP\StructurizrPHP\Core\View\Configuration\Shape;
+use StructurizrPHP\StructurizrPHP\Core\Workspace;
+use StructurizrPHP\StructurizrPHP\Infrastructure\Http\SymfonyRequestFactory;
+use StructurizrPHP\StructurizrPHP\SDK\Client;
+use StructurizrPHP\StructurizrPHP\SDK\Credentials;
+use StructurizrPHP\StructurizrPHP\SDK\UrlMap;
+use Symfony\Component\HttpClient\Psr18Client;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$workspace = new Workspace(
+    $id = (string)\getenv('STRUCTURIZR_WORKSPACE_ID'),
+    $name = 'Getting Started',
+    $description = 'This is a model of my software system. by structurizr-php/structurizr-php'
+);
+$workspace->getModel()->setEnterprise(new Enterprise('Structurizr PHP'));
+$client = new Client(
+    new Credentials((string) \getenv('STRUCTURIZR_API_KEY'), (string) \getenv('STRUCTURIZR_API_SECRET')),
+    new UrlMap('https://api.structurizr.com'),
+    new Psr18Client(),
+    new SymfonyRequestFactory(),
+);
+
+$softwareSystem = $workspace->getModel()->addSoftwareSystem(
+    $name = 'Software System',
+    $description = 'My software system.',
+    Location::internal()
+);
+
+$appGateway = $softwareSystem->addContainer('Application Gateway', 'System Gateway', 'Azure AppGateway');
+
+$php = $softwareSystem->addContainer('Backend', 'Handles requests', 'PHP');
+$php->addTags('PHP');
+
+$db = $softwareSystem->addContainer('Database', 'Stores data', 'PostgreSQL');
+$db->addTags('DATABASE');
+
+$vnet = $workspace->getModel()->addDeploymentNode('vnet01', 'prod', 'Virtual Network', 'vnet_prod_eus_01', 1);
+
+$subnetDb = $vnet->addDeploymentNode('subnet03', 'prod', 'Database Subnet', 'subnet_db_01', 1);
+$subnetDb->add($db);
+
+$appSubnet = $vnet->addDeploymentNode('subnet02', 'prod', 'Application Subnet', 'subnet_app_01', 2);
+$appSubnet->add($php);
+
+$appGatewaySubnet = $vnet->addDeploymentNode('subnet01', 'prod', 'AppGateway Subnet', 'subnet_app_gw_01', 1);
+$appGatewaySubnet->add($appGateway);
+
+$appGatewayAppRelationship = $appGatewaySubnet->usesDeploymentNode($appSubnet, "Send requests", "port: 443");
+$appDBRelationship = $appSubnet->usesDeploymentNode($subnetDb, "Reads data", 'port: 5432');
+
+$deploymentView = $workspace->getViews()->createDeploymentView($softwareSystem, 'deployment', 'An example of a System Deployment diagram.');
+$deploymentView->addAllDeploymentNodes();
+$deploymentView->addRelationship($appGatewayAppRelationship);
+$deploymentView->addRelationship($appDBRelationship);
+
+$workspace->getViews()->getConfiguration()->getStyles()->addElementStyle('DATABASE')
+    ->shape(Shape::cylinder())
+    ->background('#0064a5')
+    ->color('#ffffff');
+
+$workspace->getViews()->getConfiguration()->getStyles()->addElementStyle('PHP')
+    ->shape(Shape::hexagon())
+    ->background("#787CB5")
+    ->color("#ffffff");
+
+$client->put($workspace);

--- a/src/StructurizrPHP/Core/Model/Container.php
+++ b/src/StructurizrPHP/Core/Model/Container.php
@@ -68,26 +68,15 @@ final class Container extends StaticStructureElement
         return $data;
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     */
     public static function hydrate(array $containerData, SoftwareSystem $parent, Model $model) : self
     {
         $container = new self($containerData['id'], $parent, $model);
-
-        $model->idGenerator()->found((string) $containerData['id']);
-
-        if (isset($containerData['name'])) {
-            $container->setName($containerData['name']);
-        }
 
         if (isset($containerData['technology'])) {
             $container->setTechnology($containerData['technology']);
         }
 
-        if (isset($containerData['description'])) {
-            $container->setDescription($containerData['description']);
-        }
+        parent::hydrateElement($container, $containerData);
 
         return $container;
     }

--- a/src/StructurizrPHP/Core/Model/ContainerInstance.php
+++ b/src/StructurizrPHP/Core/Model/ContainerInstance.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\StructurizrPHP\Core\Model;
+
+/**
+ * Represents a deployment instance of a {@link Container}, which can be added to a {@link DeploymentNode}.
+ */
+final class ContainerInstance extends DeploymentElement
+{
+    private const DEFAULT_HEALTH_CHECK_INTERVAL_IN_SECONDS = 60;
+    private const DEFAULT_HEALTH_CHECK_TIMEOUT_IN_MILLISECONDS = 0;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    /**
+     * @var int
+     */
+    private $instanceId;
+
+    /**
+     * @var array
+     */
+    private $healthChecks;
+
+    public function __construct(Container $container, int $instanceId, string $environment, string $id, Model $model)
+    {
+        parent::__construct($id, $model);
+        $this->setEnvironment($environment);
+        $this->container = $container;
+        $this->instanceId = $instanceId;
+        $this->healthChecks = [];
+        $this->addTags(Tags::CONTAINER_INSTANCE);
+    }
+
+    public function getContainer(): Container
+    {
+        return $this->container;
+    }
+
+    public function getCanonicalName() : string
+    {
+        return $this->container->getCanonicalName() . "[" . $this->instanceId . "]";
+    }
+
+    public function toArray(): array
+    {
+        $data = \array_merge(
+            [
+                'containerId' => $this->container->id(),
+                'instanceId' => $this->instanceId,
+                'healthChecks' => [],
+            ],
+            parent::toArray()
+        );
+
+        return $data;
+    }
+
+    public static function hydrate(array $containerInstanceData, Model $model) : self
+    {
+        $instance = new self(
+            $model->getElement($containerInstanceData['containerId']),
+            $containerInstanceData['instanceId'],
+            $containerInstanceData['environment'],
+            $containerInstanceData['id'],
+            $model
+        );
+
+        parent::hydrateDeploymentElement($instance, $containerInstanceData);
+
+        return $instance;
+    }
+}

--- a/src/StructurizrPHP/Core/Model/DeploymentElement.php
+++ b/src/StructurizrPHP/Core/Model/DeploymentElement.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\StructurizrPHP\Core\Model;
+
+abstract class DeploymentElement extends Element
+{
+    public const DEFAULT_DEPLOYMENT_ENVIRONMENT = 'Deafault';
+
+    /**
+     * @var string
+     */
+    private $environment = self::DEFAULT_DEPLOYMENT_ENVIRONMENT;
+
+    public function getEnvironment(): string
+    {
+        return $this->environment;
+    }
+
+    public function setEnvironment(string $environment): void
+    {
+        $this->environment = $environment;
+    }
+
+    public static function hydrateDeploymentElement(DeploymentElement $element, array $elementData) : void
+    {
+        $element->setEnvironment($elementData['environment']);
+
+        parent::hydrateElement($element, $elementData);
+    }
+
+    public function toArray(): array
+    {
+        return \array_merge(
+            ['environment' => $this->environment],
+            parent::toArray()
+        );
+    }
+}

--- a/src/StructurizrPHP/Core/Model/DeploymentNode.php
+++ b/src/StructurizrPHP/Core/Model/DeploymentNode.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\StructurizrPHP\Core\Model;
+
+use StructurizrPHP\StructurizrPHP\Core\Model\Relationship\InteractionStyle;
+
+/**
+ * <p>
+ *   Represents a deployment node, which is something like:
+ * </p>
+ *
+ * <ul>
+ *     <li>Physical infrastructure (e.g. a physical server or device)</li>
+ *     <li>Virtualised infrastructure (e.g. IaaS, PaaS, a virtual machine)</li>
+ *     <li>Containerised infrastructure (e.g. a Docker container)</li>
+ *     <li>Database server</li>
+ *     <li>Java EE web/application server</li>
+ *     <li>Microsoft IIS</li>
+ *     <li>etc</li>
+ * </ul>
+ */
+final class DeploymentNode extends DeploymentElement
+{
+    /**
+     * @var DeploymentNode|null
+     */
+    private $parent;
+
+    /**
+     * @var string|null
+     */
+    private $technology;
+
+    /**
+     * @var DeploymentNode[]
+     */
+    private $children;
+
+    /**
+     * @var int
+     */
+    private $instances;
+
+    /**
+     * @var ContainerInstance[]
+     */
+    private $containerInstances;
+
+    public function __construct(string $id, Model $model)
+    {
+        parent::__construct($id, $model);
+        $this->instances = 1;
+        $this->children = [];
+        $this->containerInstances = [];
+    }
+
+    public function setInstances(int $instances): void
+    {
+        $this->instances = $instances;
+    }
+
+    public function setTechnology(?string $technology): void
+    {
+        $this->technology = $technology;
+    }
+
+    public function setParent(DeploymentNode $parent): void
+    {
+        $this->parent = $parent;
+    }
+
+    public function getParent(): ?DeploymentNode
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @return ContainerInstance[]
+     */
+    public function getContainerInstances(): array
+    {
+        return $this->containerInstances;
+    }
+
+    /**
+     * @return self[]
+     */
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function addDeploymentNode(string $name, ?string $environment = null, ?string $description = null, ?string $technology = null, ?int $instances = null, ?Properties $properties = null) : self
+    {
+        $deploymentNode = $this->getModel()->addDeploymentNodeWithParent($this, $name, $environment, $description, $technology, $instances, $properties);
+        $this->children[] = $deploymentNode;
+
+        return $deploymentNode;
+    }
+
+    public function add(Container $container, bool $replicateContainerRelationships = true) : ContainerInstance
+    {
+        $containerInstance = $this->getModel()->addContainerInstance($this, $container, $replicateContainerRelationships);
+
+        $this->containerInstances[] = $containerInstance;
+
+        return $containerInstance;
+    }
+
+    public function usesDeploymentNode(
+        DeploymentNode $deploymentNode,
+        string $description = "Uses",
+        string $technology = null,
+        InteractionStyle $interactionStyle = null
+    ) : Relationship {
+        return $this->getModel()->addRelationship(
+            $this,
+            $deploymentNode,
+            $description,
+            $technology,
+            $interactionStyle
+        );
+    }
+
+    public function toArray() : array
+    {
+        $data = \array_merge(
+            [
+                'id' => $this->id(),
+                'name' => $this->getName(),
+                'environment' => $this->getEnvironment(),
+                'children' => \array_map(function (DeploymentNode $child) {
+                    return $child->toArray();
+                }, $this->children),
+                'containerInstances' => \array_map(function (ContainerInstance $containerInstance) {
+                    return $containerInstance->toArray();
+                }, $this->containerInstances),
+                'instances' => $this->instances,
+            ],
+            parent::toArray()
+        );
+
+        if ($this->technology !== null) {
+            $data['technology'] = $this->technology;
+        }
+
+        if ($this->parent) {
+            $data['parent'] = $this->parent->id();
+        }
+
+        return $data;
+    }
+
+    public function tags(): Tags
+    {
+        // deployment nodes don't have any tags
+        return new Tags();
+    }
+
+    public function getCanonicalName() : string
+    {
+        if ($this->parent !== null) {
+            return $this->parent->getCanonicalName() . self::CANONICAL_NAME_SEPARATOR . parent::formatForCanonicalName($this->getName());
+        } else {
+            return self::CANONICAL_NAME_SEPARATOR . "Deployment" . self::CANONICAL_NAME_SEPARATOR . parent::formatForCanonicalName($this->getEnvironment()) . self::CANONICAL_NAME_SEPARATOR . parent::formatForCanonicalName($this->getName());
+        }
+    }
+
+    public static function hydrate(array $deploymentNodeData, Model $model) : self
+    {
+        $deploymentNode = new self($deploymentNodeData['id'], $model);
+        $deploymentNode->instances = $deploymentNodeData['instances'];
+        $deploymentNode->setName($deploymentNodeData['name']);
+
+        if (isset($deploymentNodeData['parent'])) {
+            $deploymentNode->parent = $model->getElement($deploymentNodeData['parent']);
+        }
+
+        if (isset($deploymentNodeData['technology'])) {
+            $deploymentNode->technology = $deploymentNodeData['technology'];
+        }
+
+        if (isset($deploymentNodeData['children'])) {
+            if (\is_array($deploymentNodeData['children'])) {
+                foreach ($deploymentNodeData['children'] as $childData) {
+                    $deploymentNode->children[] = self::hydrate($childData, $model);
+                }
+            }
+        }
+
+        if (isset($deploymentNodeData['containerInstances'])) {
+            if (\is_array($deploymentNodeData['containerInstances'])) {
+                foreach ($deploymentNodeData['containerInstances'] as $containerInstanceData) {
+                    $deploymentNode->containerInstances[] = ContainerInstance::hydrate($containerInstanceData, $model);
+                }
+            }
+        }
+
+        parent::hydrateDeploymentElement($deploymentNode, $deploymentNodeData);
+
+        return $deploymentNode;
+    }
+
+    public static function hydrateChildrenRelationships(DeploymentNode $deploymentNode, array $deploymentNodeData) : void
+    {
+        foreach ($deploymentNode->children as $child) {
+            foreach ($deploymentNodeData['children'] as $childData) {
+                if ($childData['id'] === $child->id()) {
+                    parent::hydrateRelationships($child, $childData);
+
+                    self::hydrateChildrenRelationships($child, $childData);
+                }
+            }
+        }
+    }
+}

--- a/src/StructurizrPHP/Core/Model/ModelItem.php
+++ b/src/StructurizrPHP/Core/Model/ModelItem.php
@@ -71,4 +71,26 @@ abstract class ModelItem
             'properties' => $this->properties->toArray(),
         ];
     }
+
+    public static function hydrateModelItem(ModelItem $modelItem, array $modelItemData, Model $model) : void
+    {
+        $model->idGenerator()->found($modelItemData['id']);
+
+        $modelItem->id = $modelItemData['id'];
+
+        if (isset($modelItemData['tags'])) {
+            $modelItem->tags = new Tags(...\explode(', ', $modelItemData['tags']));
+        }
+
+        if (isset($modelItemData['properties'])) {
+            $properties = new Properties();
+            if (\is_array($modelItemData['properties'])) {
+                foreach ($modelItemData['properties'] as $key => $value) {
+                    $properties->addProperty(new Property($key, $value));
+                }
+            }
+
+            $modelItem->properties = $properties;
+        }
+    }
 }

--- a/src/StructurizrPHP/Core/Model/Person.php
+++ b/src/StructurizrPHP/Core/Model/Person.php
@@ -46,12 +46,6 @@ final class Person extends StaticStructureElement
         $this->location = $location;
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     public static function hydrate(array $personData, Model $model) : self
     {
         $person = new self(
@@ -61,53 +55,11 @@ final class Person extends StaticStructureElement
 
         $model->idGenerator()->found($person->id());
 
-        if (isset($personData['name'])) {
-            $person->setName($personData['name']);
-        }
-
-        if (isset($personData['description'])) {
-            $person->setDescription($personData['description']);
-        }
-
         if (isset($personData['location'])) {
             $person->setLocation(Location::hydrate($personData['location']));
         }
 
-        if (isset($personData['tags'])) {
-            $person->setTags(new Tags(...\explode(', ', $personData['tags'])));
-        }
-
-        if (isset($personData['url'])) {
-            $person->setUrl($personData['url']);
-        }
-
-        if (isset($personData['properties'])) {
-            $properties = new Properties();
-            if (\is_array($personData['properties'])) {
-                foreach ($personData['properties'] as $key => $value) {
-                    $properties->addProperty(new Property($key, $value));
-                }
-            }
-
-            $person->setProperties($properties);
-        }
-
-        if (isset($personData['relationships'])) {
-            if (\is_array($personData['relationships'])) {
-                foreach ($personData['relationships'] as $relationshipData) {
-                    $relationship = Relationship::hydrate($relationshipData, $person, $model);
-                    $person->addRelationship($relationship);
-                }
-            }
-        }
-
-        // sort relationships by ID
-        \usort(
-            $person->relationships,
-            function (Relationship $relationshipA, Relationship $relationshipB) {
-                return (int)$relationshipA->id() > (int)$relationshipB->id() ? 1 : 0;
-            }
-        );
+        parent::hydrateElement($person, $personData);
 
         return $person;
     }

--- a/src/StructurizrPHP/Core/Model/Relationship.php
+++ b/src/StructurizrPHP/Core/Model/Relationship.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace StructurizrPHP\StructurizrPHP\Core\Model;
 
-use StructurizrPHP\StructurizrPHP\Assertion;
 use StructurizrPHP\StructurizrPHP\Core\Model\Relationship\InteractionStyle;
 
 final class Relationship extends ModelItem
@@ -42,6 +41,11 @@ final class Relationship extends ModelItem
      * @var InteractionStyle
      */
     private $interactionStyle;
+
+    /**
+     * @var string|null
+     */
+    private $linkedRelationshipId;
 
     public function __construct(
         string $id,
@@ -73,6 +77,16 @@ final class Relationship extends ModelItem
         $this->interactionStyle = $interactionStyle;
     }
 
+    public function getInteractionStyle(): InteractionStyle
+    {
+        return $this->interactionStyle;
+    }
+
+    public function getTechnology(): ?string
+    {
+        return $this->technology;
+    }
+
     public function setTechnology(?string $technology): void
     {
         $this->technology = $technology;
@@ -93,6 +107,11 @@ final class Relationship extends ModelItem
         return $this->description;
     }
 
+    public function setLinkedRelationshipId(?string $linkedRelationshipId): void
+    {
+        $this->linkedRelationshipId = $linkedRelationshipId;
+    }
+
     public function getSource(): Element
     {
         return $this->source;
@@ -110,19 +129,17 @@ final class Relationship extends ModelItem
             parent::toArray()
         );
 
-        if ($this->technology) {
+        if (isset($this->linkedRelationshipId)) {
+            $data['linkedRelationshipId'] = $this->linkedRelationshipId;
+        }
+
+        if (isset($this->technology)) {
             $data['technology'] = $this->technology;
         }
 
         return $data;
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress MixedArgumentTypeCoercion
-     */
     public static function hydrate(array $relationshipData, Element $source, Model $model) : self
     {
         $relationship = new Relationship(
@@ -138,7 +155,13 @@ final class Relationship extends ModelItem
             $relationship->setTechnology($relationshipData['technology']);
         }
 
-        $model->idGenerator()->found($relationship->id());
+        if (isset($relationshipData['linkedRelationshipId'])) {
+            $relationship->linkedRelationshipId = $relationshipData['linkedRelationshipId'];
+        }
+
+        parent::hydrateModelItem($relationship, $relationshipData, $model);
+
+        $model->addRelationshipToInternalStructures($relationship);
 
         return $relationship;
     }

--- a/src/StructurizrPHP/Core/Model/StaticStructureElement.php
+++ b/src/StructurizrPHP/Core/Model/StaticStructureElement.php
@@ -22,8 +22,8 @@ abstract class StaticStructureElement extends Element
         string $description = "Uses",
         string $technology = null,
         InteractionStyle $interactionStyle = null
-    ) : void {
-        $this->model()->addRelationship(
+    ) : Relationship {
+        return $this->getModel()->addRelationship(
             $this,
             $softwareSystem,
             $description,
@@ -37,8 +37,8 @@ abstract class StaticStructureElement extends Element
         string $description = "Uses",
         string $technology = null,
         InteractionStyle $interactionStyle = null
-    ) : void {
-        $this->model()->addRelationship(
+    ) : Relationship {
+        return $this->getModel()->addRelationship(
             $this,
             $container,
             $description,

--- a/src/StructurizrPHP/Core/Model/Tags.php
+++ b/src/StructurizrPHP/Core/Model/Tags.php
@@ -23,6 +23,7 @@ final class Tags
     public const CONTAINER = "Container";
     public const COMPONENT = "Component";
     public const RELATIONSHIP = "Relationship";
+    public const CONTAINER_INSTANCE = "Container Instance";
 
     /**
      * @var string[]

--- a/src/StructurizrPHP/Core/View/AutomaticLayout.php
+++ b/src/StructurizrPHP/Core/View/AutomaticLayout.php
@@ -65,10 +65,6 @@ final class AutomaticLayout
         ];
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     */
     public static function hydrate(array $automaticLayoutData) : self
     {
         return new self(

--- a/src/StructurizrPHP/Core/View/Configuration.php
+++ b/src/StructurizrPHP/Core/View/Configuration.php
@@ -50,11 +50,6 @@ final class Configuration
         ];
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedAssignment
-     */
     public static function hydrate(array $configurationData) : self
     {
         $configuration = new self();

--- a/src/StructurizrPHP/Core/View/Configuration/ElementStyle.php
+++ b/src/StructurizrPHP/Core/View/Configuration/ElementStyle.php
@@ -220,12 +220,6 @@ final class ElementStyle
         return $data;
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArrayOffset
-     * @psalm-suppress MixedAssignment
-     */
     public static function hydrate(array $elementData) : self
     {
         $element = new self($elementData['tag']);

--- a/src/StructurizrPHP/Core/View/Configuration/Styles.php
+++ b/src/StructurizrPHP/Core/View/Configuration/Styles.php
@@ -53,12 +53,6 @@ final class Styles
         ];
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArrayOffset
-     * @psalm-suppress MixedAssignment
-     */
     public static function hydrate(array $stylesData) : self
     {
         $styles = new self();

--- a/src/StructurizrPHP/Core/View/DefaultLayoutMergeStrategy.php
+++ b/src/StructurizrPHP/Core/View/DefaultLayoutMergeStrategy.php
@@ -27,10 +27,6 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Relationship;
  */
 final class DefaultLayoutMergeStrategy implements LayoutMergeStrategy
 {
-    /**
-     * @psalm-suppress PossiblyNullArgument
-     * @psalm-suppress PossiblyNullReference
-     */
     public function copyLayoutInformation(View $sourceView, View $destinationView): void
     {
         if (!$destinationView->getPaperSize() && $sourceView->getPaperSize()) {
@@ -61,10 +57,6 @@ final class DefaultLayoutMergeStrategy implements LayoutMergeStrategy
         }
     }
 
-    /**
-     * @psalm-suppress PossiblyNullArgument
-     * @psalm-suppress PossiblyNullReference
-     */
     protected function findRelationshipViewByRelationship(View $view, Relationship $relationship) : ?RelationshipView
     {
         foreach ($view->getRelationships() as $rv) {
@@ -80,10 +72,6 @@ final class DefaultLayoutMergeStrategy implements LayoutMergeStrategy
         return null;
     }
 
-    /**
-     * @psalm-suppress PossiblyNullArgument
-     * @psalm-suppress PossiblyNullReference
-     */
     protected function findRelationshipViewByRelationshipView(View $view, RelationshipView $relationshipView) : ?RelationshipView
     {
         foreach ($view->getRelationships() as $rv) {

--- a/src/StructurizrPHP/Core/View/DeploymentView.php
+++ b/src/StructurizrPHP/Core/View/DeploymentView.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\StructurizrPHP\Core\View;
+
+use StructurizrPHP\StructurizrPHP\Core\Model\DeploymentNode;
+use StructurizrPHP\StructurizrPHP\Core\Model\Model;
+use StructurizrPHP\StructurizrPHP\Core\Model\Relationship;
+use StructurizrPHP\StructurizrPHP\Core\Model\SoftwareSystem;
+
+final class DeploymentView extends View
+{
+    /**
+     * @var Model
+     */
+    private $model;
+
+    /**
+     * @var string|null
+     */
+    private $environment;
+
+    public function __construct(SoftwareSystem $softwareSystem, string $description, string $key, ViewSet $viewSet)
+    {
+        parent::__construct($softwareSystem, $description, $key, $viewSet);
+
+        $this->model = $softwareSystem->getModel();
+    }
+
+    public function setEnvironment(?string $environment): void
+    {
+        $this->environment = $environment;
+    }
+
+    public function addAllDeploymentNodes() : void
+    {
+        foreach ($this->getModel()->getDeploymentNodes() as $deploymentNode) {
+            $this->add($deploymentNode);
+        }
+    }
+
+    public function add(DeploymentNode $deploymentNode, bool $addRelationships = true) : void
+    {
+        if ($this->addContainerInstancesAndDeploymentNodes($deploymentNode, $addRelationships)) {
+            $parent = $deploymentNode->getParent();
+
+            while ($parent !== null) {
+                $this->addElement($parent, $addRelationships);
+                $parent = $parent->getParent();
+            }
+        }
+    }
+
+    public function addRelationship(Relationship $relationship): ?RelationshipView
+    {
+        return parent::addRelationship($relationship);
+    }
+
+    private function addContainerInstancesAndDeploymentNodes(DeploymentNode $deploymentNode, bool $addRelationships) : bool
+    {
+        $hasContainers = false;
+        foreach ($deploymentNode->getContainerInstances() as $containerInstance) {
+            $container = $containerInstance->getContainer();
+
+            if ($this->softwareSystem === null || $container->getParent()->equals($this->softwareSystem)) {
+                $this->addElement($containerInstance, $addRelationships);
+                $hasContainers = true;
+            }
+        }
+
+        foreach ($deploymentNode->getChildren() as $child) {
+            $hasContainers = (bool) ($hasContainers | $this->addContainerInstancesAndDeploymentNodes($child, $addRelationships));
+        }
+
+        if ($hasContainers) {
+            $this->addElement($deploymentNode, $addRelationships);
+        }
+
+        return $hasContainers;
+    }
+
+    public function toArray() : array
+    {
+        return \array_merge(
+            [
+                'environment' => $this->environment,
+            ],
+            parent::toArray()
+        );
+    }
+
+    public static function hydrate(array $viewData, ViewSet $viewSet) : self
+    {
+        $view = new self(
+            $viewSet->getModel()->getElement($viewData['softwareSystemId']),
+            $viewData['description'],
+            $viewData['key'],
+            $viewSet
+        );
+
+        if (isset($viewData['environment'])) {
+            $view->environment = $viewData['environment'];
+        }
+
+        parent::hydrateView($view, $viewData);
+
+        return $view;
+    }
+}

--- a/src/StructurizrPHP/Core/View/DynamicView.php
+++ b/src/StructurizrPHP/Core/View/DynamicView.php
@@ -37,10 +37,6 @@ final class DynamicView extends View
      */
     private $sequenceNumber;
 
-    /**
-     * @psalm-suppress ArgumentTypeCoercion
-     * @psalm-suppress PropertyTypeCoercion
-     */
     public function __construct(Model $model, string $key, string $description, ViewSet $viewSet, ?Element $element = null)
     {
         parent::__construct($element, $key, $description, $viewSet);
@@ -56,8 +52,8 @@ final class DynamicView extends View
 
     public static function softwareSystem(SoftwareSystem $softwareSystem, string $key, string $description, ViewSet $viewSet) : self
     {
-        $view = new self($softwareSystem->model(), $description, $key, $viewSet, $softwareSystem);
-        $view->model = $softwareSystem->model();
+        $view = new self($softwareSystem->getModel(), $description, $key, $viewSet, $softwareSystem);
+        $view->model = $softwareSystem->getModel();
         $view->element = $softwareSystem;
 
         return $view;
@@ -65,7 +61,7 @@ final class DynamicView extends View
 
     public static function container(Container $container, string $key, string $description, ViewSet $viewSet) : self
     {
-        $view = new self($container->model(), $key, $description, $viewSet, $container);
+        $view = new self($container->getModel(), $key, $description, $viewSet, $container);
         $view->softwareSystem = $container->getParent();
         $view->element = $container->getParent();
 
@@ -84,13 +80,6 @@ final class DynamicView extends View
         return $this->addRelationshipWithDescription($relationship, $description, $this->sequenceNumber->getNext());
     }
 
-    /**
-     * @psalm-suppress PossiblyNullArgument
-     * @psalm-suppress PossiblyNullReference
-     * @psalm-suppress PossiblyNullOperand
-     * @psalm-suppress PossiblyUndefinedMethod
-     * @psalm-suppress MixedArgument
-     */
     private function checkElement(Element $elementToBeAdded) : void
     {
         if (!($elementToBeAdded instanceof Person) && !($elementToBeAdded instanceof SoftwareSystem) && !($elementToBeAdded instanceof Container) /*&& !(elementToBeAdded instanceof Component)*/) {
@@ -144,9 +133,6 @@ final class DynamicView extends View
         }
     }
 
-    /**
-     * @psalm-suppress PossiblyNullReference
-     */
     public function toArray() : array
     {
         return \array_merge(
@@ -157,22 +143,14 @@ final class DynamicView extends View
         );
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArrayAccess
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress ArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullReference
-     */
     public static function hydrate(array $viewData, ViewSet $viewSet) : self
     {
         $view = new self(
-            $viewSet->model(),
+            $viewSet->getModel(),
             $viewData['description'],
             $viewData['key'],
             $viewSet,
-            isset($viewData['softwareSystemId']) ? $viewSet->model()->getElement($viewData['softwareSystemId']) : null
+            isset($viewData['softwareSystemId']) ? $viewSet->getModel()->getElement($viewData['softwareSystemId']) : null
         );
 
         if (isset($viewData['paperSize'])) {
@@ -181,7 +159,7 @@ final class DynamicView extends View
 
         if (isset($viewData['elements'])) {
             foreach ($viewData['elements'] as $elementData) {
-                $elementView = $view->addElement($viewSet->model()->getElement($elementData['id']), false);
+                $elementView = $view->addElement($viewSet->getModel()->getElement($elementData['id']), false);
 
                 if (isset($elementData['x']) && isset($elementData['y'])) {
                     $elementView

--- a/src/StructurizrPHP/Core/View/ElementView.php
+++ b/src/StructurizrPHP/Core/View/ElementView.php
@@ -85,4 +85,17 @@ final class ElementView
             'y' => $this->y,
         ];
     }
+
+    public static function hydrate(array $elementViewData, Element $element) : self
+    {
+        $elementView = new self($element);
+
+        if (\array_key_exists('x', $elementViewData) && \array_key_exists('y', $elementViewData)) {
+            $elementView
+                ->setX((int)$elementViewData['x'])
+                ->setY((int)$elementViewData['y']);
+        }
+
+        return $elementView;
+    }
 }

--- a/src/StructurizrPHP/Core/View/RelationshipView.php
+++ b/src/StructurizrPHP/Core/View/RelationshipView.php
@@ -116,9 +116,6 @@ final class RelationshipView
         }
     }
 
-    /**
-     * @psalm-suppress MixedArgument
-     */
     public static function hydrate(Relationship $relationship, array $viewData) : self
     {
         $view = new self($relationship);

--- a/src/StructurizrPHP/Core/View/SystemContextView.php
+++ b/src/StructurizrPHP/Core/View/SystemContextView.php
@@ -43,55 +43,18 @@ final class SystemContextView extends StaticView
         );
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArrayAccess
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress ArgumentTypeCoercion
-     * @psalm-suppress PossiblyNullReference
-     */
     public static function hydrate(array $viewData, ViewSet $viewSet) : self
     {
         $view = new self(
-            $viewSet->model()->getElement($viewData['softwareSystemId']),
+            $viewSet->getModel()->getElement($viewData['softwareSystemId']),
             $viewData['description'],
             $viewData['key'],
             $viewSet
         );
 
-        if (isset($viewData['title'])) {
-            $view->setTitle($viewData['title']);
-        }
+        $view->enterpriseBoundaryVisible = $viewData['enterpriseBoundaryVisible'];
 
-        if (isset($viewData['paperSize'])) {
-            $view->setPaperSize(PaperSize::hydrate($viewData['paperSize']));
-        }
-
-        foreach ($viewData['elements'] as $elementData) {
-            $elementView = $view->addElement($viewSet->model()->getElement($elementData['id']), false);
-
-            if (isset($elementData['x']) && isset($elementData['y'])) {
-                $elementView
-                    ->setX((int) $elementData['x'])
-                    ->setY((int) $elementData['y']);
-            }
-        }
-
-        if (isset($viewData['relationships'])) {
-            foreach ($viewData['relationships'] as $relationshipData) {
-                $relationshipView = RelationshipView::hydrate(
-                    $view->getModel()->getRelationship($relationshipData['id']),
-                    $relationshipData
-                );
-
-                $view->relationshipsViews[] = $relationshipView;
-            }
-        }
-
-        if (isset($viewData['automaticLayout'])) {
-            $view->automaticLayout = AutomaticLayout::hydrate($viewData['automaticLayout']);
-        }
+        parent::hydrateView($view, $viewData);
 
         return $view;
     }

--- a/src/StructurizrPHP/Core/View/SystemLandscapeView.php
+++ b/src/StructurizrPHP/Core/View/SystemLandscapeView.php
@@ -54,54 +54,18 @@ final class SystemLandscapeView extends StaticView
         );
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     * @psalm-suppress MixedArrayAccess
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress PossiblyNullReference
-     */
     public static function hydrate(array $viewData, ViewSet $viewSet) : self
     {
         $view = new SystemLandscapeView(
-            $viewSet->model(),
+            $viewSet->getModel(),
             $viewData['description'],
             $viewData['key'],
             $viewSet
         );
 
-        if (isset($viewData['title'])) {
-            $view->setTitle($viewData['title']);
-        }
+        $view->enterpriseBoundaryVisible = $viewData['enterpriseBoundaryVisible'];
 
-        if ($viewData['paperSize']) {
-            $view->setPaperSize(PaperSize::hydrate($viewData['paperSize']));
-        }
-
-        foreach ($viewData['elements'] as $elementData) {
-            $elementView = $view->addElement($viewSet->model()->getElement($elementData['id']), false);
-
-            if (isset($elementData['x']) && isset($elementData['y'])) {
-                $elementView
-                    ->setX((int) $elementData['x'])
-                    ->setY((int) $elementData['y']);
-            }
-        }
-
-        if (isset($viewData['relationships'])) {
-            foreach ($viewData['relationships'] as $relationshipData) {
-                $relationshipView = RelationshipView::hydrate(
-                    $view->getModel()->getRelationship($relationshipData['id']),
-                    $relationshipData
-                );
-
-                $view->relationshipsViews[] = $relationshipView;
-            }
-        }
-
-        if (isset($viewData['automaticLayout'])) {
-            $view->automaticLayout = AutomaticLayout::hydrate($viewData['automaticLayout']);
-        }
+        parent::hydrateView($view, $viewData);
 
         return $view;
     }

--- a/src/StructurizrPHP/Core/Workspace.php
+++ b/src/StructurizrPHP/Core/Workspace.php
@@ -87,10 +87,6 @@ final class Workspace
         ];
     }
 
-    /**
-     * @psalm-suppress InvalidArgument
-     * @psalm-suppress MixedArgument
-     */
     public static function hydrate(array $workspaceData) : self
     {
         $workspace = new self(

--- a/src/StructurizrPHP/SDK/Client.php
+++ b/src/StructurizrPHP/SDK/Client.php
@@ -87,8 +87,6 @@ final class Client
 
             $workspaceDefinition = \json_encode($workspace->toArray(self::AGENT_NAME), JSON_THROW_ON_ERROR);
 
-//            dump($workspaceDefinition);
-//            die();
             $url = $this->urlMap->workspaceUrl($workspace->id());
 
             $response = $this->httpClient->sendRequest(

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerInstanceTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerInstanceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\Model;
+
+use PHPUnit\Framework\TestCase;
+use StructurizrPHP\StructurizrPHP\Core\Model\ContainerInstance;
+use StructurizrPHP\StructurizrPHP\Core\Model\Model;
+
+final class ContainerInstanceTest extends TestCase
+{
+    public function test_hydrate_container_instance()
+    {
+        $model = new Model();
+        $softwareSystem = $model->addSoftwareSystem('system');
+        $container = $model->addContainer($softwareSystem, 'container', 'test', 'php');
+        $deploymentNode = $model->addDeploymentNode('node');
+        $instance = $model->addContainerInstance($deploymentNode, $container);
+
+        $newModel = new Model();
+        $softwareSystem = $newModel->addSoftwareSystem('system');
+        $container = $newModel->addContainer($softwareSystem, 'container', 'test', 'php');
+        $deploymentNode = $newModel->addDeploymentNode('node');
+
+        $this->assertEquals($instance, ContainerInstance::hydrate($instance->toArray(), $newModel));
+    }
+}

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerTest.php
@@ -24,7 +24,6 @@ final class ContainerTest extends TestCase
         $model = new Model();
         $software = $model->addSoftwareSystem('software');
         $container = new Container("1", $software, $model);
-
         $container->setParent($software);
 
         $this->assertEquals($container, Container::hydrate($container->toArray(), $software, $model));

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/DeploymentNodeTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/DeploymentNodeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\Model;
+
+use PHPUnit\Framework\TestCase;
+use StructurizrPHP\StructurizrPHP\Core\Model\DeploymentNode;
+use StructurizrPHP\StructurizrPHP\Core\Model\Model;
+use StructurizrPHP\StructurizrPHP\Core\Model\Properties;
+use StructurizrPHP\StructurizrPHP\Core\Model\Property;
+use StructurizrPHP\StructurizrPHP\Core\Model\Tags;
+
+final class DeploymentNodeTest extends TestCase
+{
+    public function test_hydrating_deployment_node()
+    {
+        $node = new DeploymentNode('1', $model = new Model());
+        $node->setEnvironment('prod');
+        $node->setInstances(1);
+        $node->setDescription('test');
+        $node->setTechnology('vm');
+        $node->setProperties(new Properties(new Property('test', 'test')));
+        $node->setTags(new Tags(Tags::RELATIONSHIP));
+
+        $this->assertEquals($node, DeploymentNode::hydrate($node->toArray(), $model));
+    }
+
+    public function test_hydrating_deployment_node_with_child()
+    {
+        $model = new Model();
+        $node = $model->addDeploymentNode('vnet01', 'prod');
+        $node->setInstances(1);
+        $node->setDescription('test');
+        $node->setTechnology('vnet');
+        $node->setProperties(new Properties(new Property('test', 'test')));
+        $node->setTags(new Tags(Tags::RELATIONSHIP));
+
+        $this->assertEquals($node, DeploymentNode::hydrate($node->toArray(), $model));
+    }
+
+    public function test_hydrating_deployment_node_with_child_with_relationships()
+    {
+        $model = new Model();
+        $deploymentNode = $model->addDeploymentNode('node_01');
+        $nodeChild01 = $deploymentNode->addDeploymentNode('node_child_01');
+        $nodeChild02 = $deploymentNode->addDeploymentNode('node_child_02');
+
+        $nodeChild01->usesDeploymentNode($nodeChild02, 'for fun');
+
+        $newNode = DeploymentNode::hydrate($deploymentNode->toArray(), $model);
+        DeploymentNode::hydrateChildrenRelationships($newNode, $deploymentNode->toArray());
+        $this->assertEquals($deploymentNode, $newNode);
+    }
+}

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ModelTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ModelTest.php
@@ -66,4 +66,17 @@ final class ModelTest extends TestCase
 
         $this->assertEquals($model, Model::hydrate($model->toArray()));
     }
+
+    public function test_hydrating_model_with_software_system_and_deployment_node()
+    {
+        $model = new Model();
+
+        $model->addPerson('test01', 'test01');
+        $model->addSoftwareSystem('test03', 'test03');
+        $model->addDeploymentNode('vm01', 'prod');
+
+        $model->addSoftwareSystem('test04', 'test04');
+
+        $this->assertEquals($model, Model::hydrate($model->toArray()));
+    }
 }

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/PersonTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/PersonTest.php
@@ -45,6 +45,9 @@ final class PersonTest extends TestCase
 
         $person->usesSoftwareSystem($softwareSystem, 'description', 'technology');
 
-        $this->assertEquals($person, Person::hydrate($person->toArray(), $model));
+        $newPerson = Person::hydrate($person->toArray(), $model);
+        Person::hydrateRelationships($newPerson, $person->toArray());
+
+        $this->assertEquals($person, $newPerson);
     }
 }

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/SoftwareSystemTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/SoftwareSystemTest.php
@@ -62,7 +62,7 @@ final class SoftwareSystemTest extends TestCase
     public function test_adding_container_twice()
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('A container named "name" already exists for this software system.');
+        $this->expectExceptionMessage('A container named "container" already exists for this software system.');
 
         $model = new Model();
         $softwareSystem = $model->addSoftwareSystem('name', 'description', Location::unspecified());

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/DeploymentViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/DeploymentViewTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\View;
+
+use PHPUnit\Framework\TestCase;
+use StructurizrPHP\StructurizrPHP\Core\Model\Model;
+use StructurizrPHP\StructurizrPHP\Core\View\DeploymentView;
+use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
+
+final class DeploymentViewTest extends TestCase
+{
+    public function test_hydrating_deployment_view()
+    {
+        $model = new Model();
+        $viewSet = new ViewSet($model);
+        $softwareSystem = $model->addSoftwareSystem('system');
+
+        $view = new DeploymentView($softwareSystem, 'test', 'test', $viewSet);
+        $view->setEnvironment('prod');
+
+        $this->assertEquals($view, DeploymentView::hydrate($view->toArray(), $viewSet));
+    }
+}

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/DynamicViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/DynamicViewTest.php
@@ -23,7 +23,7 @@ final class DynamicViewTest extends TestCase
     public function test_hydrating_dynamic_view()
     {
         $viewSet = new ViewSet(new Model());
-        $system = $viewSet->model()->addSoftwareSystem('system');
+        $system = $viewSet->getModel()->addSoftwareSystem('system');
 
         $view = $viewSet->createDynamicView($system, 'key', 'description');
 
@@ -33,9 +33,9 @@ final class DynamicViewTest extends TestCase
     public function test_hydrating_dynamic_view_with_relationships()
     {
         $viewSet = new ViewSet(new Model());
-        $system = $viewSet->model()->addSoftwareSystem('system');
-        $container = $viewSet->model()->addContainer($system, 'container', 'test', 'php');
-        $person = $viewSet->model()->addPerson('person');
+        $system = $viewSet->getModel()->addSoftwareSystem('system');
+        $container = $viewSet->getModel()->addContainer($system, 'container', 'test', 'php');
+        $person = $viewSet->getModel()->addPerson('person');
 
         $person->usesContainer($container);
 

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/SystemContextViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/SystemContextViewTest.php
@@ -23,7 +23,7 @@ final class SystemContextViewTest extends TestCase
     public function test_hydrating_system_landscape_view()
     {
         $viewSet = new ViewSet(new Model());
-        $softwareSystem = $viewSet->model()->addSoftwareSystem('name', 'description');
+        $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
         $view = $viewSet->createSystemContextView($softwareSystem, 'key', 'description');
 
         $this->assertEquals($view, SystemContextView::hydrate($view->toArray(), $viewSet));
@@ -32,7 +32,7 @@ final class SystemContextViewTest extends TestCase
     public function test_hydrating_system_landscape_view_with_automatic_layout()
     {
         $viewSet = new ViewSet(new Model());
-        $softwareSystem = $viewSet->model()->addSoftwareSystem('name', 'description');
+        $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
         $view = $viewSet->createSystemContextView($softwareSystem, 'key', 'description');
         $view->setAutomaticLayout(true);
 
@@ -42,8 +42,8 @@ final class SystemContextViewTest extends TestCase
     public function test_hydrating_system_landscape_view_with_added_people()
     {
         $viewSet = new ViewSet(new Model());
-        $softwareSystem = $viewSet->model()->addSoftwareSystem('name', 'description');
-        $person = $viewSet->model()->addPerson('name', 'description');
+        $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
+        $person = $viewSet->getModel()->addPerson('name', 'description');
         $person->usesSoftwareSystem($softwareSystem, 'description', 'technology');
 
         $view = $viewSet->createSystemContextView($softwareSystem, 'key', 'description');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/SystemLandscapeViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/SystemLandscapeViewTest.php
@@ -40,8 +40,8 @@ final class SystemLandscapeViewTest extends TestCase
     public function test_hydrating_system_landscape_view_with_added_people()
     {
         $viewSet = new ViewSet(new Model());
-        $softwareSystem = $viewSet->model()->addSoftwareSystem('name', 'description');
-        $person = $viewSet->model()->addPerson('name', 'description');
+        $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
+        $person = $viewSet->getModel()->addPerson('name', 'description');
         $person->usesSoftwareSystem($softwareSystem, 'description', 'technology');
 
         $view = $viewSet->createSystemLandscapeView('key', 'description');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/ViewSetTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/ViewSetTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\View;
+
+use PHPUnit\Framework\TestCase;
+use StructurizrPHP\StructurizrPHP\Core\Model\Model;
+use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
+
+final class ViewSetTest extends TestCase
+{
+    public function test_hydrating_view_set()
+    {
+        $viewSet = new ViewSet($model = new Model());
+
+        $this->assertEquals($viewSet, ViewSet::hydrate($viewSet->toArray(), $model));
+    }
+
+    public function test_hydrating_view_set_with_views()
+    {
+        $viewSet = new ViewSet($model = new Model());
+        $softwareSystem = $model->addSoftwareSystem('software');
+
+        $viewSet->createSystemLandscapeView('landscape', 'Landscape View');
+        $viewSet->createSystemContextView($softwareSystem, 'context', 'Context View');
+        $viewSet->createDynamicView($softwareSystem, 'dynamic', 'Dynamic View');
+        $viewSet->createDeploymentView($softwareSystem, 'deployment', 'Deployment View');
+
+        $this->assertEquals($viewSet, ViewSet::hydrate($viewSet->toArray(), $model));
+    }
+}


### PR DESCRIPTION
Thanks to DeploymentNodes we can generate following diagrams: 

![image](https://user-images.githubusercontent.com/1921950/68536092-a1321300-034d-11ea-9dac-1bc126344c1b.png)

Also I decided to remove vimeo/psalm, it'a a great tool but unfortunately I had to spent more time adding @psalm-suppress docblocks than fixing real issues. It's because of heavy usage of `toArray()` and `hydrate()` methods in core objects that are basically deserializing/serializing them into jsons. 
 