### PR TITLE
Added phpstan rule to detect missing return types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
         "friendsofphp/php-cs-fixer": "^2.15",
         "phpunit/phpunit": "^8.4",
         "symfony/var-dumper": "^4.3",
-        "phpstan/phpstan": "^0.11.19"
+        "phpstan/phpstan": "^0.11.19",
+        "phpstan/phpstan-phpunit": "^0.11.2",
+        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
     },
     "suggest": {
         "symfony/http-client": "Psr18Client http factory works out of the box with StructurizrPHP\\StructurizrPHP\\SDK\\Client",
@@ -42,6 +44,9 @@
     "scripts": {
         "phpstan": [
             "phpstan analyse -c phpstan.neon"
+        ],
+        "phpunit": [
+            "phpunit"
         ],
         "test" : [
             "php-cs-fixer fix --dry-run",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,24 @@
+includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
+    - vendor/phpstan/phpstan-phpunit/rules.neon
+    - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
+
 parameters:
     level: 6
     paths:
         - src
         - tests
         - examples
+    ignoreErrors:
+        -
+            message: '#In method \"(.*)::(toArray|map)\", return type is "array".(.*)#'
+            path: *
+        -
+            message: '#In method \"(.*)::hydrate(.*)\", parameter (.*) type is "array".(.*)#'
+            path: *
+        -
+            message: '#In method \"(.*)DataObject::__construct(.*)\", parameter (.*) type is "array".(.*)#'
+            path: *
+        -
+            message: '#(.*)#'
+            path: src/StructurizrPHP/Http/RequestFactory.php

--- a/src/StructurizrPHP/Core/Configuration/Role.php
+++ b/src/StructurizrPHP/Core/Configuration/Role.php
@@ -20,41 +20,26 @@ final class Role
      */
     private $name;
 
-    /**
-     * @param string $name
-     */
     private function __construct(string $name)
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
     public function name() : string
     {
         return $this->name;
     }
 
-    /**
-     * @return static
-     */
     public static function readWrite() : self
     {
         return new self('ReadWrite');
     }
 
-    /**
-     * @return static
-     */
     public static function readOnly() : self
     {
         return new self('ReadOnly');
     }
 
-    /**
-     * @return string
-     */
     public function toString() : string
     {
         return $this->name;

--- a/src/StructurizrPHP/Core/Documentation/Documentation.php
+++ b/src/StructurizrPHP/Core/Documentation/Documentation.php
@@ -39,7 +39,7 @@ final class Documentation
         $this->model = $model;
     }
 
-    public function addSection(Element $element, string $title, Format $format, string $content)
+    public function addSection(Element $element, string $title, Format $format, string $content) : Section
     {
         Assertion::notEmpty($title);
         Assertion::notEmpty($content);
@@ -90,7 +90,7 @@ final class Documentation
         return count($this->sections) + 1;
     }
 
-    public function setTemplate(TemplateMetadata $template)
+    public function setTemplate(TemplateMetadata $template) : void
     {
         $this->template = $template;
     }
@@ -114,7 +114,7 @@ final class Documentation
     {
         $documentation = new self($model);
 
-        $documentationDataModel = new DocumentationDataModel($documentationData);
+        $documentationDataModel = new DocumentationDataObject($documentationData);
         $documentation->sections = $documentationDataModel->hydrateSection($model);
         if ($documentationDataModel->templateExist()) {
             $documentation->template = $documentationDataModel->hydrateTemplate();
@@ -124,7 +124,7 @@ final class Documentation
     }
 }
 
-final class DocumentationDataModel
+final class DocumentationDataObject
 {
     /**
      * @var array
@@ -136,6 +136,10 @@ final class DocumentationDataModel
         $this->documentationSetData = $documentationSetData;
     }
 
+    /**
+     * @param Model $model
+     * @return Section[]
+     */
     public function hydrateSection(Model $model) : array
     {
         return \array_map(

--- a/src/StructurizrPHP/Core/Documentation/Section.php
+++ b/src/StructurizrPHP/Core/Documentation/Section.php
@@ -123,7 +123,7 @@ final class Section
         return $result;
     }
 
-    private function str_hashcode($s) : int
+    private function str_hashcode(string $s) : int
     {
         $hash = 0;
         $len = mb_strlen($s, 'UTF-8');

--- a/src/StructurizrPHP/Core/Documentation/StructurizrDocumentationTemplate.php
+++ b/src/StructurizrPHP/Core/Documentation/StructurizrDocumentationTemplate.php
@@ -15,7 +15,7 @@ use StructurizrPHP\StructurizrPHP\Core\Model\SoftwareSystem;
 
 class StructurizrDocumentationTemplate extends DocumentationTemplate
 {
-    public function addContextSection(SoftwareSystem $softwareSystem, Format $format, string $content)
+    public function addContextSection(SoftwareSystem $softwareSystem, Format $format, string $content) : void
     {
         $this->addSection($softwareSystem, "Context", $format, $content);
     }

--- a/src/StructurizrPHP/Core/Model/ModelItem.php
+++ b/src/StructurizrPHP/Core/Model/ModelItem.php
@@ -51,6 +51,9 @@ abstract class ModelItem
         $this->tags = $tags;
     }
 
+    /**
+     * @param string ...$tags
+     */
     public function addTags(string ...$tags) : void
     {
         foreach ($tags as $tag) {

--- a/src/StructurizrPHP/Core/Model/Person.php
+++ b/src/StructurizrPHP/Core/Model/Person.php
@@ -64,7 +64,7 @@ final class Person extends StaticStructureElement
         return $person;
     }
 
-    public function uses(SoftwareSystem $softwareSystem, string $description)
+    public function uses(SoftwareSystem $softwareSystem, string $description) : void
     {
         $this->getModel()->addRelationship($this, $softwareSystem, $description);
     }

--- a/src/StructurizrPHP/Core/Model/Properties.php
+++ b/src/StructurizrPHP/Core/Model/Properties.php
@@ -15,8 +15,14 @@ namespace StructurizrPHP\StructurizrPHP\Core\Model;
 
 final class Properties
 {
+    /**
+     * @var Property[]
+     */
     private $properties;
 
+    /**
+     * @param Property ...$properties
+     */
     public function __construct(Property ...$properties)
     {
         $this->properties = $properties;

--- a/src/StructurizrPHP/Core/Model/Tags.php
+++ b/src/StructurizrPHP/Core/Model/Tags.php
@@ -38,6 +38,9 @@ final class Tags
      */
     private $tags;
 
+    /**
+     * @param string ...$tags
+     */
     public function __construct(string ...$tags)
     {
         $this->tags = $tags;

--- a/src/StructurizrPHP/Core/View/Branding.php
+++ b/src/StructurizrPHP/Core/View/Branding.php
@@ -34,7 +34,7 @@ class Branding
         $this->font = $font;
     }
 
-    public function setLogo(string $url)
+    public function setLogo(string $url) : void
     {
         Assertion::startsWith($url, 'data:image/');
         $this->logo = $url;

--- a/src/StructurizrPHP/Core/View/RelationshipView.php
+++ b/src/StructurizrPHP/Core/View/RelationshipView.php
@@ -80,6 +80,9 @@ final class RelationshipView
         $this->description = $description;
     }
 
+    /**
+     * @param Vertex ...$vertices
+     */
     public function setVertices(Vertex ...$vertices) : void
     {
         $this->vertices = $vertices;

--- a/src/StructurizrPHP/Core/View/ViewSet.php
+++ b/src/StructurizrPHP/Core/View/ViewSet.php
@@ -260,7 +260,7 @@ final class ViewSet
             return $viewSet;
         }
 
-        $viewSetDataModel = new ViewSetDataModel($viewSetData);
+        $viewSetDataModel = new ViewSetDataObject($viewSetData);
 
         if ($viewSetDataModel->hasViews('systemLandscapeViews')) {
             $viewSet->systemLandscapeViews = $viewSetDataModel->map(
@@ -305,7 +305,7 @@ final class ViewSet
     }
 }
 
-final class ViewSetDataModel
+final class ViewSetDataObject
 {
     /**
      * @var array

--- a/src/StructurizrPHP/Http/RequestFactory.php
+++ b/src/StructurizrPHP/Http/RequestFactory.php
@@ -17,5 +17,12 @@ use Psr\Http\Message\RequestInterface;
 
 interface RequestFactory
 {
+    /**
+     * @param string $uri
+     * @param string $method
+     * @param array<mixed> $headers
+     * @param string|null $body
+     * @return RequestInterface
+     */
     public function create(string $uri, string $method, array $headers, ?string $body) : RequestInterface;
 }

--- a/tests/StructurizrPHP/Tests/Unit/Core/Documentation/DocumentationTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Documentation/DocumentationTest.php
@@ -21,7 +21,7 @@ use StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\AbstractWorkspaceTestBas
 
 final class DocumentationTest extends AbstractWorkspaceTestBase
 {
-    public function test_empty_title_added()
+    public function test_empty_title_added() : void
     {
         $softwareSystem = $this->model->addSoftwareSystem('Software System', 'Description');
         $testcase = new Documentation($this->model);
@@ -31,7 +31,7 @@ final class DocumentationTest extends AbstractWorkspaceTestBase
         $testcase->addSection($softwareSystem, '', Format::markdown(), 'test content');
     }
 
-    public function test_empty_content_added()
+    public function test_empty_content_added() : void
     {
         $softwareSystem = $this->model->addSoftwareSystem('Software System', 'Description');
         $testcase = new Documentation($this->model);
@@ -41,7 +41,7 @@ final class DocumentationTest extends AbstractWorkspaceTestBase
         $testcase->addSection($softwareSystem, 'test', Format::markdown(), '');
     }
 
-    public function test_addSection_ThrowsAnException_WhenTheRelatedElementIsNotPresentInTheAssociatedModel()
+    public function test_addSection_ThrowsAnException_WhenTheRelatedElementIsNotPresentInTheAssociatedModel() : void
     {
         try {
             $softwareSystem = $this->model->addSoftwareSystem('Software System', 'Description');
@@ -56,14 +56,14 @@ final class DocumentationTest extends AbstractWorkspaceTestBase
         }
     }
 
-    public function test_hydrating_empty_documentation()
+    public function test_hydrating_empty_documentation() : void
     {
         $documentation = new Documentation($this->model);
 
         $this->assertEquals($documentation, Documentation::hydrate($documentation->toArray(), $this->model));
     }
 
-    public function test_hydrating_with_section()
+    public function test_hydrating_with_section() : void
     {
         $softwareSystem = $this->model->addSoftwareSystem('Software System', 'Description');
         $documentation = new Documentation($this->model);
@@ -71,7 +71,7 @@ final class DocumentationTest extends AbstractWorkspaceTestBase
         $this->assertEquals($documentation, Documentation::hydrate($documentation->toArray(), $this->model));
     }
 
-    public function test_hydrating_with_template()
+    public function test_hydrating_with_template() : void
     {
         $softwareSystem = $this->model->addSoftwareSystem('Software System', 'Description');
         $documentation = new Documentation($this->model);

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerInstanceTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerInstanceTest.php
@@ -19,7 +19,7 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Model;
 
 final class ContainerInstanceTest extends TestCase
 {
-    public function test_hydrate_container_instance()
+    public function test_hydrate_container_instance() : void
     {
         $model = new Model();
         $softwareSystem = $model->addSoftwareSystem('system');

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ContainerTest.php
@@ -19,7 +19,7 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Model;
 
 final class ContainerTest extends TestCase
 {
-    public function test_hydrating_container()
+    public function test_hydrating_container() : void
     {
         $model = new Model();
         $software = $model->addSoftwareSystem('software');

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/DeploymentNodeTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/DeploymentNodeTest.php
@@ -22,7 +22,7 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Tags;
 
 final class DeploymentNodeTest extends TestCase
 {
-    public function test_hydrating_deployment_node()
+    public function test_hydrating_deployment_node() : void
     {
         $node = new DeploymentNode('1', $model = new Model());
         $node->setEnvironment('prod');
@@ -35,7 +35,7 @@ final class DeploymentNodeTest extends TestCase
         $this->assertEquals($node, DeploymentNode::hydrate($node->toArray(), $model));
     }
 
-    public function test_hydrating_deployment_node_with_child()
+    public function test_hydrating_deployment_node_with_child() : void
     {
         $model = new Model();
         $node = $model->addDeploymentNode('vnet01', 'prod');
@@ -48,7 +48,7 @@ final class DeploymentNodeTest extends TestCase
         $this->assertEquals($node, DeploymentNode::hydrate($node->toArray(), $model));
     }
 
-    public function test_hydrating_deployment_node_with_child_with_relationships()
+    public function test_hydrating_deployment_node_with_child_with_relationships() : void
     {
         $model = new Model();
         $deploymentNode = $model->addDeploymentNode('node_01');

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/ModelTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/ModelTest.php
@@ -18,7 +18,7 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Model;
 
 final class ModelTest extends TestCase
 {
-    public function test_hydrating_empty_model()
+    public function test_hydrating_empty_model() : void
     {
         $model = new Model();
 
@@ -26,7 +26,7 @@ final class ModelTest extends TestCase
         $this->assertTrue($model->isEmpty());
     }
 
-    public function test_hydrating_model_with_people()
+    public function test_hydrating_model_with_people() : void
     {
         $model = new Model();
 
@@ -35,7 +35,7 @@ final class ModelTest extends TestCase
         $this->assertEquals($model, Model::hydrate($model->toArray()));
     }
 
-    public function test_hydrating_model_with_software_system()
+    public function test_hydrating_model_with_software_system() : void
     {
         $model = new Model();
 
@@ -44,7 +44,7 @@ final class ModelTest extends TestCase
         $this->assertEquals($model, Model::hydrate($model->toArray()));
     }
 
-    public function test_hydrating_model_with_software_system_and_person()
+    public function test_hydrating_model_with_software_system_and_person() : void
     {
         $model = new Model();
 
@@ -54,7 +54,7 @@ final class ModelTest extends TestCase
         $this->assertEquals($model, Model::hydrate($model->toArray()));
     }
 
-    public function test_hydrating_model_with_software_system_and_person_relationship()
+    public function test_hydrating_model_with_software_system_and_person_relationship() : void
     {
         $model = new Model();
 
@@ -68,7 +68,7 @@ final class ModelTest extends TestCase
         $this->assertEquals($model, Model::hydrate($model->toArray()));
     }
 
-    public function test_hydrating_model_with_software_system_and_deployment_node()
+    public function test_hydrating_model_with_software_system_and_deployment_node() : void
     {
         $model = new Model();
 

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/PersonTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/PersonTest.php
@@ -22,14 +22,14 @@ use StructurizrPHP\StructurizrPHP\Core\Model\Property;
 
 final class PersonTest extends TestCase
 {
-    public function test_hydrating_person()
+    public function test_hydrating_person() : void
     {
         $person = new Person('1', $model = new Model());
 
         $this->assertEquals($person, Person::hydrate($person->toArray(), $model));
     }
 
-    public function test_hydrating_person_with_properties()
+    public function test_hydrating_person_with_properties() : void
     {
         $person = new Person('1', $model = new Model());
         $person->setProperties(new Properties(new Property('key', 'value')));
@@ -37,7 +37,7 @@ final class PersonTest extends TestCase
         $this->assertEquals($person, Person::hydrate($person->toArray(), $model));
     }
 
-    public function test_hydrating_person_with_relationship()
+    public function test_hydrating_person_with_relationship() : void
     {
         $model = new Model();
         $person = $model->addPerson('name', 'description', Location::unspecified());

--- a/tests/StructurizrPHP/Tests/Unit/Core/Model/SoftwareSystemTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Model/SoftwareSystemTest.php
@@ -23,14 +23,14 @@ use StructurizrPHP\StructurizrPHP\Exception\RuntimeException;
 
 final class SoftwareSystemTest extends TestCase
 {
-    public function test_hydrating_software_system()
+    public function test_hydrating_software_system() : void
     {
         $softwareSystem = new SoftwareSystem('1', $model = new Model());
 
         $this->assertEquals($softwareSystem, SoftwareSystem::hydrate($softwareSystem->toArray(), $model));
     }
 
-    public function test_hydrating_software_system_with_properties()
+    public function test_hydrating_software_system_with_properties() : void
     {
         $softwareSystem = new SoftwareSystem('1', $model = new Model());
         $softwareSystem->setProperties(new Properties(new Property('key', 'value')));
@@ -38,7 +38,7 @@ final class SoftwareSystemTest extends TestCase
         $this->assertEquals($softwareSystem, SoftwareSystem::hydrate($softwareSystem->toArray(), $model));
     }
 
-    public function test_hydrating_software_system_with_relationship()
+    public function test_hydrating_software_system_with_relationship() : void
     {
         $model = new Model();
         $person = $model->addPerson('name', 'description', Location::unspecified());
@@ -49,7 +49,7 @@ final class SoftwareSystemTest extends TestCase
         $this->assertEquals($softwareSystem, SoftwareSystem::hydrate($softwareSystem->toArray(), $model));
     }
 
-    public function test_hydrating_software_system_with_container()
+    public function test_hydrating_software_system_with_container() : void
     {
         $model = new Model();
         $softwareSystem = $model->addSoftwareSystem('name', 'description', Location::unspecified());
@@ -59,7 +59,7 @@ final class SoftwareSystemTest extends TestCase
         $this->assertEquals($softwareSystem, SoftwareSystem::hydrate($softwareSystem->toArray(), $model));
     }
 
-    public function test_adding_container_twice()
+    public function test_adding_container_twice() : void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('A container named "container" already exists for this software system.');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/BrandingTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/BrandingTest.php
@@ -17,14 +17,14 @@ use StructurizrPHP\StructurizrPHP\Core\View\Branding;
 
 final class BrandingTest extends TestCase
 {
-    public function test_hydrating_empty_branding()
+    public function test_hydrating_empty_branding() : void
     {
         $branding = new Branding();
 
         $this->assertEquals($branding, Branding::hydrate($branding->toArray()));
     }
 
-    public function test_hydrating_branding_with_logo()
+    public function test_hydrating_branding_with_logo() : void
     {
         $branding = new Branding();
         $branding->setLogo(ImageUtils::getImageAsDataUri(__DIR__ . '/assets/black-pixel.png'));

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/ConfigurationTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/ConfigurationTest.php
@@ -19,14 +19,14 @@ use StructurizrPHP\StructurizrPHP\Core\View\Configuration;
 
 final class ConfigurationTest extends TestCase
 {
-    public function test_hydrating_configuration()
+    public function test_hydrating_configuration() : void
     {
         $configuration = new Configuration();
 
         $this->assertEquals($configuration, Configuration::hydrate($configuration->toArray()));
     }
 
-    public function test_hydrating_configuration_with_branding()
+    public function test_hydrating_configuration_with_branding() : void
     {
         $configuration = new Configuration();
         $configuration->setBranding(new Branding());

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/DeploymentViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/DeploymentViewTest.php
@@ -20,7 +20,7 @@ use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
 
 final class DeploymentViewTest extends TestCase
 {
-    public function test_hydrating_deployment_view()
+    public function test_hydrating_deployment_view() : void
     {
         $model = new Model();
         $viewSet = new ViewSet($model);

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/DynamicViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/DynamicViewTest.php
@@ -20,7 +20,7 @@ use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
 
 final class DynamicViewTest extends TestCase
 {
-    public function test_hydrating_dynamic_view()
+    public function test_hydrating_dynamic_view() : void
     {
         $viewSet = new ViewSet(new Model());
         $system = $viewSet->getModel()->addSoftwareSystem('system');
@@ -30,7 +30,7 @@ final class DynamicViewTest extends TestCase
         $this->assertEquals($view, DynamicView::hydrate($view->toArray(), $viewSet));
     }
 
-    public function test_hydrating_dynamic_view_with_relationships()
+    public function test_hydrating_dynamic_view_with_relationships() : void
     {
         $viewSet = new ViewSet(new Model());
         $system = $viewSet->getModel()->addSoftwareSystem('system');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/Styles/ElementStyleTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/Styles/ElementStyleTest.php
@@ -20,14 +20,14 @@ use StructurizrPHP\StructurizrPHP\Core\View\Configuration\Shape;
 
 final class ElementStyleTest extends TestCase
 {
-    public function test_hydrating_element_style()
+    public function test_hydrating_element_style() : void
     {
         $elementStyle = new ElementStyle('tag');
 
         $this->assertEquals($elementStyle, ElementStyle::hydrate($elementStyle->toArray()));
     }
 
-    public function test_hydrating_element_style_with_all_properties()
+    public function test_hydrating_element_style_with_all_properties() : void
     {
         $elementStyle = new ElementStyle('tag');
 

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/Styles/StylesTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/Styles/StylesTest.php
@@ -19,14 +19,14 @@ use StructurizrPHP\StructurizrPHP\Core\View\Configuration\Styles;
 
 final class StylesTest extends TestCase
 {
-    public function test_hydrating_styles()
+    public function test_hydrating_styles() : void
     {
         $styles = new Styles();
 
         $this->assertEquals($styles, Styles::hydrate($styles->toArray()));
     }
 
-    public function test_hydrating_styles_with_element_styles()
+    public function test_hydrating_styles_with_element_styles() : void
     {
         $styles = new Styles();
 

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/SystemContextViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/SystemContextViewTest.php
@@ -20,7 +20,7 @@ use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
 
 final class SystemContextViewTest extends TestCase
 {
-    public function test_hydrating_system_landscape_view()
+    public function test_hydrating_system_landscape_view() : void
     {
         $viewSet = new ViewSet(new Model());
         $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
@@ -29,7 +29,7 @@ final class SystemContextViewTest extends TestCase
         $this->assertEquals($view, SystemContextView::hydrate($view->toArray(), $viewSet));
     }
 
-    public function test_hydrating_system_landscape_view_with_automatic_layout()
+    public function test_hydrating_system_landscape_view_with_automatic_layout() : void
     {
         $viewSet = new ViewSet(new Model());
         $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');
@@ -39,7 +39,7 @@ final class SystemContextViewTest extends TestCase
         $this->assertEquals($view, SystemContextView::hydrate($view->toArray(), $viewSet));
     }
 
-    public function test_hydrating_system_landscape_view_with_added_people()
+    public function test_hydrating_system_landscape_view_with_added_people() : void
     {
         $viewSet = new ViewSet(new Model());
         $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/SystemLandscapeViewTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/SystemLandscapeViewTest.php
@@ -20,7 +20,7 @@ use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
 
 final class SystemLandscapeViewTest extends TestCase
 {
-    public function test_hydrating_system_landscape_view()
+    public function test_hydrating_system_landscape_view() : void
     {
         $viewSet = new ViewSet(new Model());
         $view = $viewSet->createSystemLandscapeView('key', 'description');
@@ -28,7 +28,7 @@ final class SystemLandscapeViewTest extends TestCase
         $this->assertEquals($view, SystemLandscapeView::hydrate($view->toArray(), $viewSet));
     }
 
-    public function test_hydrating_system_landscape_view_with_automatic_layout()
+    public function test_hydrating_system_landscape_view_with_automatic_layout() : void
     {
         $viewSet = new ViewSet(new Model());
         $view = $viewSet->createSystemLandscapeView('key', 'description');
@@ -37,7 +37,7 @@ final class SystemLandscapeViewTest extends TestCase
         $this->assertEquals($view, SystemLandscapeView::hydrate($view->toArray(), $viewSet));
     }
 
-    public function test_hydrating_system_landscape_view_with_added_people()
+    public function test_hydrating_system_landscape_view_with_added_people() : void
     {
         $viewSet = new ViewSet(new Model());
         $softwareSystem = $viewSet->getModel()->addSoftwareSystem('name', 'description');

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/ViewSetTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/ViewSetTest.php
@@ -19,14 +19,14 @@ use StructurizrPHP\StructurizrPHP\Core\View\ViewSet;
 
 final class ViewSetTest extends TestCase
 {
-    public function test_hydrating_view_set()
+    public function test_hydrating_view_set() : void
     {
         $viewSet = new ViewSet($model = new Model());
 
         $this->assertEquals($viewSet, ViewSet::hydrate($viewSet->toArray(), $model));
     }
 
-    public function test_hydrating_view_set_with_views()
+    public function test_hydrating_view_set_with_views() : void
     {
         $viewSet = new ViewSet($model = new Model());
         $softwareSystem = $model->addSoftwareSystem('software');

--- a/tests/StructurizrPHP/Tests/Unit/Core/WorkspaceTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/WorkspaceTest.php
@@ -23,7 +23,7 @@ use StructurizrPHP\StructurizrPHP\Core\Workspace;
 
 final class WorkspaceTest extends TestCase
 {
-    public function test_hydraing_workspace()
+    public function test_hydraing_workspace() : void
     {
         $workspace = new Workspace(
             "1",
@@ -34,7 +34,7 @@ final class WorkspaceTest extends TestCase
         $this->assertEquals($workspace, Workspace::hydrate($workspace->toArray("test")));
     }
 
-    public function test_hydraing_with_relationships_and_views()
+    public function test_hydraing_with_relationships_and_views() : void
     {
         $workspace = new Workspace(
             "1",


### PR DESCRIPTION
This PR adds more rules to phpstan analysis ignoring in the same time toArray|hydrate array related errors 