### PR TITLE
Added more phpstan & cs fixer rules

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -30,6 +30,8 @@ return PhpCsFixer\Config::create()
         'strict_comparison' => true,
         'return_type_declaration' => ['space_before' => 'one'],
         'class_attributes_separation' => ['elements' => ['const', 'property', 'method']],
-        'no_unused_imports' => true
+        'no_unused_imports' => true,
+        'declare_strict_types' => true,
+        'blank_line_after_opening_tag' => true
     ])
     ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/var-dumper": "^4.3",
         "phpstan/phpstan": "^0.11.19",
         "phpstan/phpstan-phpunit": "^0.11.2",
-        "thecodingmachine/phpstan-strict-rules": "^0.11.2"
+        "thecodingmachine/phpstan-strict-rules": "^0.11.2",
+        "localheinz/phpstan-rules": "^0.13.0"
     },
     "suggest": {
         "symfony/http-client": "Psr18Client http factory works out of the box with StructurizrPHP\\StructurizrPHP\\SDK\\Client",

--- a/examples/clean_workspace.php
+++ b/examples/clean_workspace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/examples/corporate_branding.php
+++ b/examples/corporate_branding.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*

--- a/examples/deployment_view.php
+++ b/examples/deployment_view.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/examples/dynamic_view.php
+++ b/examples/dynamic_view.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/examples/getting_started.php
+++ b/examples/getting_started.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/examples/shapes.php
+++ b/examples/shapes.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,24 @@ includes:
     - vendor/phpstan/phpstan-phpunit/rules.neon
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
+rules:
+    - Localheinz\PHPStan\Rules\Expressions\NoEvalRule
+    - Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
+
+services:
+    -
+        class: Localheinz\PHPStan\Rules\Classes\FinalRule
+        arguments:
+            allowAbstractClasses: true
+            classesNotRequiredToBeAbstractOrFinal:
+                - StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\AbstractWorkspaceTestBase
+                - StructurizrPHP\StructurizrPHP\Exception\Exception
+                - StructurizrPHP\StructurizrPHP\Exception\InvalidArgumentException
+                - StructurizrPHP\StructurizrPHP\Core\View\SequenceNumber\SequenceCounter
+                - StructurizrPHP\StructurizrPHP\Core\Documentation\DocumentationTemplate
+        tags:
+            - phpstan.rules.rule
+
 parameters:
     level: 6
     paths:

--- a/src/StructurizrPHP/Core/Documentation/Documentation.php
+++ b/src/StructurizrPHP/Core/Documentation/Documentation.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 /*

--- a/src/StructurizrPHP/Core/Documentation/DocumentationTemplate.php
+++ b/src/StructurizrPHP/Core/Documentation/DocumentationTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/src/StructurizrPHP/Core/Documentation/Format.php
+++ b/src/StructurizrPHP/Core/Documentation/Format.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -11,7 +13,7 @@
 
 namespace StructurizrPHP\StructurizrPHP\Core\Documentation;
 
-class Format
+final class Format
 {
     private $name;
 

--- a/src/StructurizrPHP/Core/Documentation/Section.php
+++ b/src/StructurizrPHP/Core/Documentation/Section.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/src/StructurizrPHP/Core/Documentation/StructurizrDocumentationTemplate.php
+++ b/src/StructurizrPHP/Core/Documentation/StructurizrDocumentationTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -13,7 +15,7 @@ namespace StructurizrPHP\StructurizrPHP\Core\Documentation;
 
 use StructurizrPHP\StructurizrPHP\Core\Model\SoftwareSystem;
 
-class StructurizrDocumentationTemplate extends DocumentationTemplate
+final class StructurizrDocumentationTemplate extends DocumentationTemplate
 {
     public function addContextSection(SoftwareSystem $softwareSystem, Format $format, string $content) : void
     {

--- a/src/StructurizrPHP/Core/Documentation/TemplateMetadata.php
+++ b/src/StructurizrPHP/Core/Documentation/TemplateMetadata.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -11,7 +13,7 @@
 
 namespace StructurizrPHP\StructurizrPHP\Core\Documentation;
 
-class TemplateMetadata
+final class TemplateMetadata
 {
     /**
      * @var string

--- a/src/StructurizrPHP/Core/Util/ImageUtils.php
+++ b/src/StructurizrPHP/Core/Util/ImageUtils.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -13,7 +15,7 @@ namespace StructurizrPHP\StructurizrPHP\Core\Util;
 
 use StructurizrPHP\StructurizrPHP\Assertion;
 
-class ImageUtils
+final class ImageUtils
 {
     public static function getImageAsDataUri(string $imagePath) : string
     {

--- a/src/StructurizrPHP/Core/View/Branding.php
+++ b/src/StructurizrPHP/Core/View/Branding.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -13,7 +15,7 @@ namespace StructurizrPHP\StructurizrPHP\Core\View;
 
 use StructurizrPHP\StructurizrPHP\Assertion;
 
-class Branding
+final class Branding
 {
     /**
      * @var string|null

--- a/src/StructurizrPHP/Core/View/Font.php
+++ b/src/StructurizrPHP/Core/View/Font.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -13,7 +15,7 @@ namespace StructurizrPHP\StructurizrPHP\Core\View;
 
 use StructurizrPHP\StructurizrPHP\Assertion;
 
-class Font
+final class Font
 {
     private $name;
 

--- a/tests/StructurizrPHP/Tests/Unit/Core/AbstractWorkspaceTestBase.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/AbstractWorkspaceTestBase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/tests/StructurizrPHP/Tests/Unit/Core/Configuration/UserTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Configuration/UserTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use StructurizrPHP\StructurizrPHP\Core\Configuration\Role;
 use StructurizrPHP\StructurizrPHP\Core\Configuration\User;
 
-class UserTest extends TestCase
+final class UserTest extends TestCase
 {
     public function test_equals_the_same_users() : void
     {

--- a/tests/StructurizrPHP/Tests/Unit/Core/Configuration/WorkspaceConfigurationTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Configuration/WorkspaceConfigurationTest.php
@@ -18,7 +18,7 @@ use StructurizrPHP\StructurizrPHP\Core\Configuration\Role;
 use StructurizrPHP\StructurizrPHP\Core\Configuration\WorkspaceConfiguration;
 use StructurizrPHP\StructurizrPHP\Exception\AssertionException;
 
-class WorkspaceConfigurationTest extends TestCase
+final class WorkspaceConfigurationTest extends TestCase
 {
     public function test_addUser() : void
     {

--- a/tests/StructurizrPHP/Tests/Unit/Core/Documentation/DocumentationTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/Documentation/DocumentationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *

--- a/tests/StructurizrPHP/Tests/Unit/Core/View/BrandingTest.php
+++ b/tests/StructurizrPHP/Tests/Unit/Core/View/BrandingTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the Structurizr for PHP.
  *
@@ -11,7 +13,7 @@
 
 namespace StructurizrPHP\Tests\StructurizrPHP\Tests\Unit\Core\View;
 
-use PhpCsFixer\Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 use StructurizrPHP\StructurizrPHP\Core\Util\ImageUtils;
 use StructurizrPHP\StructurizrPHP\Core\View\Branding;
 


### PR DESCRIPTION
All those PR's related to phpstan/csfixer are here to speedup review process and improve the code quality making it more unified and predictable. 
This PR adds:

- force declare strict types
- checks if all classes (with exceptions) are marked as final 
- no eval is used 