### PR TITLE
Fix for hydrating software system containers relationships

### DIFF
--- a/src/StructurizrPHP/Core/Model/Model.php
+++ b/src/StructurizrPHP/Core/Model/Model.php
@@ -597,6 +597,7 @@ final class Model
         if (\count($model->softwareSystems)) {
             foreach ($modelData['softwareSystems'] as $softwareSystemData) {
                 SoftwareSystem::hydrateRelationships($model->getElement($softwareSystemData['id']), $softwareSystemData);
+                SoftwareSystem::hydrateContainersRelationships($model->getSoftwareSystem($softwareSystemData['id']), $softwareSystemData);
             }
         }
 

--- a/src/StructurizrPHP/Core/Model/SoftwareSystem.php
+++ b/src/StructurizrPHP/Core/Model/SoftwareSystem.php
@@ -128,14 +128,21 @@ final class SoftwareSystem extends StaticStructureElement
                     $container = Container::hydrate($containerData, $softwareSystem, $model);
                     $softwareSystem->add($container);
                 }
+            }
+        }
 
+        return $softwareSystem;
+    }
+
+    public static function hydrateContainersRelationships(self $softwareSystem, array $softwareSystemData) : void
+    {
+        if (isset($softwareSystemData['containers'])) {
+            if (\is_array($softwareSystemData['containers'])) {
                 // hydrate containers missing relationships
                 foreach ($softwareSystemData['containers'] as $containerData) {
                     Container::hydrateRelationships($softwareSystem->getContainer($containerData['id']), $containerData);
                 }
             }
         }
-
-        return $softwareSystem;
     }
 }


### PR DESCRIPTION
Because of that bug it was impossible to hydrate SoftwareSystem that has Container with relationship to other SoftwareSystem that was created after the first software system. 

Example:
```
SoftwareSystemA
 - Container
    - Relationship -> SoftwareSystemB

SoftwareSystemB
```

If SoftwareSystemB was next on the list to hydrate, hydration failed 