### PR TITLE
relationshipstyle class & unit tests

### DIFF
--- a/examples/user_container_system_relationships.php
+++ b/examples/user_container_system_relationships.php
@@ -28,7 +28,7 @@ use Symfony\Component\HttpClient\Psr18Client;
 require __DIR__ . '/../vendor/autoload.php';
 
 $workspace = new Workspace(
-    $id = (string)\getenv('STRUCTURIZR_WORKSPACE_ID'),
+    $id = (string) \getenv('STRUCTURIZR_WORKSPACE_ID'),
     $name = 'Internal / External system communication',
     $description = 'This is a model of software system by structurizr-php/structurizr-php'
 );
@@ -64,6 +64,7 @@ $styles = $workspace->getViews()->getConfiguration()->getStyles();
 
 $styles->addElementStyle(Tags::CONTAINER)->background("#1168bd")->color('#ffffff');
 $styles->addElementStyle(Tags::PERSON)->background("#08427b")->color('#ffffff')->shape(Shape::person());
+$styles->addRelationshipStyle(Tags::RELATIONSHIP)->color('#ff0000');
 
 $client = new Client(
     new Credentials((string) \getenv('STRUCTURIZR_API_KEY'), (string) \getenv('STRUCTURIZR_API_SECRET')),

--- a/src/StructurizrPHP/Core/View/Configuration/RelationshipStyle.php
+++ b/src/StructurizrPHP/Core/View/Configuration/RelationshipStyle.php
@@ -13,6 +13,211 @@ declare(strict_types=1);
 
 namespace StructurizrPHP\Core\View\Configuration;
 
+use StructurizrPHP\Core\Assertion;
+use StructurizrPHP\Core\View\Routing;
+
 final class RelationshipStyle
 {
+    private const START_OF_LINE = 0;
+
+    private const END_OF_LINE = 100;
+
+    /**
+     * @var string
+     *
+     * The name of the tag to which this style applies.
+     */
+    private $tag;
+
+    /**
+     * @var int|null
+     *
+     * The thickness of the line, in pixels.
+     */
+    private $thickness;
+
+    /**
+     * @var string|null
+     *
+     * The colour of the line, as a HTML hex value (e.g. #123456).
+     */
+    private $color;
+
+    /**
+     * @var int|null
+     *
+     * The font size of the annotation, in pixels.
+     */
+    private $fontSize;
+
+    /**
+     * @var int|null
+     *
+     * The width of the annotation, in pixels.
+     */
+    private $width;
+
+    /**
+     * @var bool
+     *
+     * Whether the line should be dashed or not.
+     */
+    private $dashed;
+
+    /**
+     * @var Routing|null
+     *
+     * The routing algorithm used when rendering lines.
+     */
+    private $routing;
+
+    /**
+     * @var int|null
+     *
+     * The position of the annotation along the line; 0 (start) to 100 (end).
+     */
+    private $position;
+
+    /**
+     * @var int|null
+     *
+     * The opacity of the line/text; 0 to 100.
+     */
+    private $opacity;
+
+    public function __construct(string $tag)
+    {
+        $this->tag = $tag;
+    }
+
+    public function thickness(int $thickness) : self
+    {
+        Assertion::greaterThan($thickness, 0);
+
+        $this->thickness = $thickness;
+
+        return $this;
+    }
+
+    public function color(string $color) : self
+    {
+        Assertion::hexColorCode($color);
+
+        $this->color = strtolower($color);
+
+        return $this;
+    }
+
+    public function dashed(bool $dashed) : self
+    {
+        $this->dashed = $dashed;
+
+        return $this;
+    }
+
+    public function fontSize(int $fontSize) : self
+    {
+        Assertion::greaterThan($fontSize, 0);
+
+        $this->fontSize = $fontSize;
+
+        return $this;
+    }
+
+    public function width(int $width) : self
+    {
+        Assertion::greaterThan($width, 0);
+
+        $this->width = $width;
+
+        return $this;
+    }
+
+    public function opacity(int $opacity) : self
+    {
+        Assertion::greaterOrEqualThan($opacity, 0);
+        Assertion::lessOrEqualThan($opacity, 100);
+
+        $this->opacity = $opacity;
+
+        return $this;
+    }
+
+    public function setRouting(Routing $routing) : self
+    {
+        $this->routing = $routing;
+
+        return $this;
+    }
+
+    public function setPosition(?int $position) : self
+    {
+        if ($position === null) {
+            $this->position = null;
+        } elseif ($position < self::START_OF_LINE) {
+            $this->position = self::START_OF_LINE;
+        } elseif ($position > self::END_OF_LINE) {
+            $this->position = self::END_OF_LINE;
+        } else {
+            $this->position = $position;
+        }
+
+        return $this;
+    }
+
+    public function toArray() : array
+    {
+        $data = [
+            'tag' => $this->tag,
+            'thickness' => $this->thickness ?: null,
+            'fontSize' => $this->fontSize ?: null,
+            'color' => $this->color ?: null,
+            'width' => $this->width ?: null,
+            'dashed' => $this->dashed ?: null,
+            'opacity' => $this->opacity ?: null,
+            'routing' => $this->routing ? $this->routing->type() : null,
+            'position' => $this->position ?: null,
+        ];
+
+        return $data;
+    }
+
+    public static function hydrate(array $relationshipData) : self
+    {
+        $relationship = new self($relationshipData['tag']);
+
+        if (isset($relationshipData['thickness'])) {
+            $relationship->thickness = (int) $relationshipData['thickness'];
+        }
+
+        if (isset($relationshipData['fontSize'])) {
+            $relationship->fontSize = (int) $relationshipData['fontSize'];
+        }
+
+        if (isset($relationshipData['color'])) {
+            $relationship->color = (string) $relationshipData['color'];
+        }
+
+        if (isset($relationshipData['width'])) {
+            $relationship->width = (int) $relationshipData['width'];
+        }
+
+        if (isset($relationshipData['dashed'])) {
+            $relationship->dashed = (bool) $relationshipData['dashed'];
+        }
+
+        if (isset($relationshipData['opacity'])) {
+            $relationship->opacity = (int) $relationshipData['opacity'];
+        }
+
+        if (isset($relationshipData['routing'])) {
+            $relationship->routing = Routing::hydrate($relationshipData['routing']);
+        }
+
+        if (isset($relationshipData['position'])) {
+            $relationship->position = (int) $relationshipData['position'];
+        }
+
+        return $relationship;
+    }
 }

--- a/src/StructurizrPHP/Core/View/Configuration/Styles.php
+++ b/src/StructurizrPHP/Core/View/Configuration/Styles.php
@@ -44,12 +44,26 @@ final class Styles
         return $elementStyle;
     }
 
+    public function addRelationshipStyle(string $tag) : RelationshipStyle
+    {
+        Assertion::keyNotExists($this->elementsStyles, $tag, \sprintf("A relationship style for the tag \"%s\" already exists .", $tag));
+
+        $relationshipStyle = new RelationshipStyle($tag);
+
+        $this->relationshipsStyles[$tag] = $relationshipStyle;
+
+        return $relationshipStyle;
+    }
+
     public function toArray() : array
     {
         return [
             'elements' => \array_values(\array_map(function (ElementStyle $elementStyle) {
                 return $elementStyle->toArray();
             }, $this->elementsStyles)),
+            'relationships' => \array_values(\array_map(function (RelationshipStyle $relationshipStyle) {
+                return $relationshipStyle->toArray();
+            }, $this->relationshipsStyles)),
         ];
     }
 
@@ -60,6 +74,12 @@ final class Styles
         if (isset($stylesData['elements'])) {
             foreach ($stylesData['elements'] as $elementData) {
                 $styles->elementsStyles[$elementData['tag']] = ElementStyle::hydrate($elementData);
+            }
+        }
+
+        if (isset($stylesData['relationships'])) {
+            foreach ($stylesData['relationships'] as $relationshipData) {
+                $styles->relationshipsStyles[$relationshipData['tag']] = RelationshipStyle::hydrate($relationshipData);
             }
         }
 

--- a/src/StructurizrPHP/Core/View/Routing.php
+++ b/src/StructurizrPHP/Core/View/Routing.php
@@ -27,7 +27,7 @@ final class Routing
         return $this->type;
     }
 
-    public static function drirect() : self
+    public static function direct() : self
     {
         return new self('Direct');
     }

--- a/tests/StructurizrPHP/Tests/Core/Unit/View/Styles/RelationshipStyleTest.php
+++ b/tests/StructurizrPHP/Tests/Core/Unit/View/Styles/RelationshipStyleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Structurizr for PHP.
+ *
+ * (c) Norbert Orzechowicz <norbert@orzechowicz.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StructurizrPHP\Tests\Core\Unit\View\Styles;
+
+use PHPUnit\Framework\TestCase;
+use StructurizrPHP\Core\View\Configuration\RelationshipStyle;
+use StructurizrPHP\Core\View\Routing;
+
+final class RelationshipStyleTest extends TestCase
+{
+    public function test_hydrating_relationship_style() : void
+    {
+        $relationshipStyle = new RelationshipStyle('tag');
+
+        $this->assertEquals($relationshipStyle, RelationshipStyle::hydrate($relationshipStyle->toArray()));
+    }
+
+    public function test_hydrating_relationship_style_with_all_properties() : void
+    {
+        $relationshipStyle = new RelationshipStyle('tag');
+
+        $relationshipStyle
+            ->thickness(\random_int(1, 100))
+            ->fontSize(\random_int(1, 100))
+            ->width(\random_int(1, 100))
+            ->opacity(\random_int(0, 100))
+            ->setPosition(\random_int(0, 100))
+            ->color("#ffffff")
+            ->dashed(true)
+            ->setRouting(Routing::direct());
+
+        $this->assertEquals($relationshipStyle, RelationshipStyle::hydrate($relationshipStyle->toArray()));
+    }
+}

--- a/tests/StructurizrPHP/Tests/Core/Unit/View/Styles/StylesTest.php
+++ b/tests/StructurizrPHP/Tests/Core/Unit/View/Styles/StylesTest.php
@@ -16,6 +16,7 @@ namespace StructurizrPHP\Tests\Core\Unit\View\Styles;
 use PHPUnit\Framework\TestCase;
 use StructurizrPHP\Core\View\Configuration\Border;
 use StructurizrPHP\Core\View\Configuration\Styles;
+use StructurizrPHP\Core\View\Routing;
 
 final class StylesTest extends TestCase
 {
@@ -43,6 +44,17 @@ final class StylesTest extends TestCase
 
         $style->setDescription('description');
         $style->setMetadata(true);
+
+        $style = $styles->addRelationshipStyle('TEST3');
+        $style
+            ->thickness(\random_int(1, 100))
+            ->fontSize(\random_int(1, 100))
+            ->width(\random_int(1, 100))
+            ->opacity(\random_int(0, 100))
+            ->setPosition(\random_int(0, 100))
+            ->color("#ffffff")
+            ->dashed(true)
+            ->setRouting(Routing::direct());
 
         $this->assertEquals($styles, Styles::hydrate($styles->toArray()));
     }


### PR DESCRIPTION
Related to - https://github.com/structurizr-php/structurizr-php/issues/20 issue.

Added port of RelationshipStyle.java class & changes required to use it.
addRelationshipStyle() allows you to add styles for relationships very similar as you use addElementStyle().

There is example added in user_container_system_relationships.php