### PR TITLE
Implement removeElement in View

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.github export-ignore
+/docs export-ignore
+/examples export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.php_cs export-ignore
+/depfile.yml export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dis export-ignore

--- a/composer.json
+++ b/composer.json
@@ -53,13 +53,13 @@
             "phpstan analyse -c phpstan.neon"
         ],
         "phpunit": [
-            "phpunit"
+            "phpunit --colors=always"
         ],
         "test" : [
             "deptrac",
             "php-cs-fixer fix --dry-run",
             "@phpstan",
-            "phpunit"
+            "@phpunit"
         ],
         "cs:fix": [
             "php-cs-fixer fix"

--- a/src/StructurizrPHP/Core/Model/Element.php
+++ b/src/StructurizrPHP/Core/Model/Element.php
@@ -123,11 +123,6 @@ abstract class Element extends ModelItem
         $this->description = $description;
     }
 
-    public function equals(self $element) : bool
-    {
-        return $this->id() === $element->id();
-    }
-
     public function hasEfferentRelationshipWith(Element $destination) : bool
     {
         try {

--- a/src/StructurizrPHP/Core/Model/ModelItem.php
+++ b/src/StructurizrPHP/Core/Model/ModelItem.php
@@ -71,6 +71,11 @@ abstract class ModelItem
         $this->properties = $properties;
     }
 
+    public function equals(self $modelItem) : bool
+    {
+        return $this->id() === $modelItem->id();
+    }
+
     public function toArray() : array
     {
         return [

--- a/src/StructurizrPHP/Core/View/ComponentView.php
+++ b/src/StructurizrPHP/Core/View/ComponentView.php
@@ -15,6 +15,7 @@ namespace StructurizrPHP\Core\View;
 
 use StructurizrPHP\Core\Model\Component;
 use StructurizrPHP\Core\Model\Container;
+use StructurizrPHP\Core\Model\Element;
 
 final class ComponentView extends StaticView
 {
@@ -96,5 +97,10 @@ final class ComponentView extends StaticView
         parent::hydrateView($view, $viewData);
 
         return $view;
+    }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return true;
     }
 }

--- a/src/StructurizrPHP/Core/View/ContainerView.php
+++ b/src/StructurizrPHP/Core/View/ContainerView.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace StructurizrPHP\Core\View;
 
 use StructurizrPHP\Core\Model\Container;
+use StructurizrPHP\Core\Model\Element;
 use StructurizrPHP\Core\Model\SoftwareSystem;
 
 final class ContainerView extends StaticView
@@ -64,5 +65,10 @@ final class ContainerView extends StaticView
         parent::hydrateView($view, $viewData);
 
         return $view;
+    }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return true;
     }
 }

--- a/src/StructurizrPHP/Core/View/DeploymentView.php
+++ b/src/StructurizrPHP/Core/View/DeploymentView.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace StructurizrPHP\Core\View;
 
 use StructurizrPHP\Core\Model\DeploymentNode;
+use StructurizrPHP\Core\Model\Element;
 use StructurizrPHP\Core\Model\Model;
 use StructurizrPHP\Core\Model\Relationship;
 use StructurizrPHP\Core\Model\SoftwareSystem;
@@ -116,5 +117,10 @@ final class DeploymentView extends View
         parent::hydrateView($view, $viewData);
 
         return $view;
+    }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return true;
     }
 }

--- a/src/StructurizrPHP/Core/View/DynamicView.php
+++ b/src/StructurizrPHP/Core/View/DynamicView.php
@@ -196,4 +196,9 @@ final class DynamicView extends View
 
         return $view;
     }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return true;
+    }
 }

--- a/src/StructurizrPHP/Core/View/RelationshipView.php
+++ b/src/StructurizrPHP/Core/View/RelationshipView.php
@@ -70,7 +70,7 @@ final class RelationshipView
         }
     }
 
-    public function getRelationship() : ?Relationship
+    public function getRelationship() : Relationship
     {
         return $this->relationship;
     }

--- a/src/StructurizrPHP/Core/View/StaticView.php
+++ b/src/StructurizrPHP/Core/View/StaticView.php
@@ -25,9 +25,19 @@ abstract class StaticView extends View
         $this->addElement($softwareSystem, $addRelationships);
     }
 
+    public function removeSoftwareSystem(SoftwareSystem $softwareSystem) : void
+    {
+        $this->removeElement($softwareSystem);
+    }
+
     public function addPerson(Person $person, bool $addRelationships = true) : void
     {
         $this->addElement($person, $addRelationships);
+    }
+
+    public function removePerson(Person $person) : void
+    {
+        $this->removeElement($person);
     }
 
     public function addAllSoftwareSystems(bool $addRelationships = true) : void
@@ -59,6 +69,11 @@ abstract class StaticView extends View
     public function addRelationship(Relationship $relationship) : ?RelationshipView
     {
         return parent::addRelationship($relationship);
+    }
+
+    public function removeRelationship(Relationship $relationship) : void
+    {
+        parent::removeRelationship($relationship);
     }
 
     abstract public function addAllElements() : void;

--- a/src/StructurizrPHP/Core/View/SystemContextView.php
+++ b/src/StructurizrPHP/Core/View/SystemContextView.php
@@ -79,4 +79,9 @@ final class SystemContextView extends StaticView
 
         return $view;
     }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return !$this->softwareSystem->equals($element);
+    }
 }

--- a/src/StructurizrPHP/Core/View/SystemLandscapeView.php
+++ b/src/StructurizrPHP/Core/View/SystemLandscapeView.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace StructurizrPHP\Core\View;
 
+use StructurizrPHP\Core\Model\Element;
 use StructurizrPHP\Core\Model\Model;
 
 final class SystemLandscapeView extends StaticView
@@ -68,5 +69,10 @@ final class SystemLandscapeView extends StaticView
         parent::hydrateView($view, $viewData);
 
         return $view;
+    }
+
+    protected function canBeRemoved(Element $element) : bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
Allow to remove element from prepared view. Useful for complex diagrams with a lot of systems or other elements.

Example usage:
```php
$scv = $workspace->getViews()->createSystemContextView($system, 'System', 'C1 - system diagram');
$scv->addAllSoftwareSystems();
$scv->removeSoftwareSystem($external);
```

Bonus: `.gitignore` file to prepare this excellent library to release :rocket: 