### PR TITLE
Enumerations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
         "ext-iconv": "*",
         "beberlei/assert": "^3.2",
         "psr/http-client": "^1.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.1",
+        "thunderer/platenum": "^0.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/StructurizrPHP/Core/Documentation/Format.php
+++ b/src/StructurizrPHP/Core/Documentation/Format.php
@@ -13,43 +13,27 @@ declare(strict_types=1);
 
 namespace StructurizrPHP\Core\Documentation;
 
-use StructurizrPHP\Core\Assertion;
+use Thunder\Platenum\Enum\ConstantsEnumTrait;
 
+/**
+ * @method static static markdown();
+ * @method static static asciiDoc();
+ */
 final class Format
 {
-    private const MARKDOWN = 'Markdown';
+    private const markdown = 'Markdown';
 
-    private const ASCII_DOC = 'AsciiDoc';
+    private const asciiDoc = 'AsciiDoc';
 
-    /**
-     * @var string
-     */
-    private $name;
-
-    private function __construct(string $name)
-    {
-        $this->name = $name;
-    }
+    use ConstantsEnumTrait;
 
     public function name() : string
     {
-        return $this->name;
-    }
-
-    public static function markdown() : self
-    {
-        return new self(self::MARKDOWN);
-    }
-
-    public static function asciiDoc() : self
-    {
-        return new self(self::ASCII_DOC);
+        return (string) $this->getValue();
     }
 
     public static function hydrate(string $name) : self
     {
-        Assertion::inArray($name, [self::MARKDOWN, self::ASCII_DOC]);
-
-        return new self($name);
+        return static::fromValue($name);
     }
 }


### PR DESCRIPTION
Hi, a lot of the classes in this library effectively act as enumerations. This PR fully leverages their power and simplifies the implementation using a dedicated library.

The candidates are (random order): `Format`, `DecisionStatus`, `Role`, `InteractionStyle`, `Shape`, `Location`, `Border`, `PaperSize`, `RankDirection`, and `Routing`. I also see that a `Tag` enum could be extracted from `Tags`.

Currently, this PR is a WIP showcasing `Format` class implementation [using Platenum](https://github.com/thunderer/Platenum). The public interface was intentionally kept without any change, but ideally, I'd like to:

- replace the internals of classes listed above with enumerations (reduces class bodies to a list of constants and usage of `ConstantsEnumTrait`),
- keep uppercase constants (requires `Format::markdown()` change in [`extensions-php` repository](https://github.com/structurizr-php/extensions-php/blob/master/src/StructurizrPHP/AdrTools/AdrToolsImporter.php#L69)),
- remove the `name()` and `hydrate()` methods (and use native `::getValue()` and `::fromValue()`).

I'd like to have your approval before updating this PR with the full changeset.